### PR TITLE
basic moves

### DIFF
--- a/commands/advanceMove.js
+++ b/commands/advanceMove.js
@@ -1,0 +1,61 @@
+const { DynamoDB } = require('aws-sdk');
+const { tag } = require('../content/commonParams');
+const _ = require('lodash');
+const ddb = require('../utils/dynamodb');
+const params = require('../utils/params');
+const hunterHelper = require('../utils/hunter');
+
+module.exports = {
+  name: 'advancemove',
+  aliases: ['advance', 'adv'],
+  description: 'Allows for advanced outcome of a move.',
+  params: [
+    { 
+      name: '- Key (text) (required)', 
+      value: "The key of the move to advance as part of a hunter improvement. Such as `ksa`, `aup`, `ho`, `iam`, `ms`, `ps`, `rabs`, `um` or the key for a special move."
+    },
+    tag
+  ],
+	async execute(message, args) {
+
+    const userIdFromMention = params.checkAllArgs(args, params.parseUserIdFromMentionParam);
+    const userIdInQuestion = userIdFromMention ? userIdFromMention : message.author.id;
+    const hunter = await ddb.getHunter(userIdInQuestion);
+    if (_.isEmpty(hunter)) {
+      message.channel.send("Could not find your hunter!");
+      return;
+    }
+
+    // TODO: Add ability to remove an advanced move from list
+
+    const moveToAdvance = params.parseBasicMoveKey(args);
+    // TODO: still need to search for special moves here if we don't find a basic move
+    if (!moveToAdvance) {
+      message.channel.send('BLARRR You must include a move you want to advance!');
+      return;
+    }
+
+    const advancedMoves = hunter.advancedMoves ? hunter.advancedMoves : [];
+
+    advancedMoves.push(moveToAdvance);
+
+    const marshalled = DynamoDB.Converter.marshall({advancedMoves});
+    // dynamodb properties
+    const UpdateExpression = `set advancedMoves = :val`;
+    const ExpressionAttributeValues = {
+      ":val": marshalled.advancedMoves,
+    };
+    
+    const updatedHunter = await ddb.updateHunter(userIdInQuestion, UpdateExpression, ExpressionAttributeValues);
+
+    if (!updatedHunter) {
+      message.channel.send('Something has gone wrong! Help!');
+      return;
+    }
+
+    console.log('hunter passing in to stats embed', updatedHunter);
+    
+    const statSheet = hunterHelper.statsEmbed(updatedHunter);
+    message.channel.send({ embed: statSheet });
+	}
+};

--- a/commands/mark.js
+++ b/commands/mark.js
@@ -17,6 +17,7 @@ module.exports = {
 
     if (!update) {
       message.channel.send('You must include a vital sign (experience, harm, or luck) to mark.');
+      return;
     }
 
     const userIdFromMention = params.checkAllArgs(args, params.parseUserIdFromMentionParam);

--- a/commands/move.js
+++ b/commands/move.js
@@ -44,9 +44,15 @@ module.exports = {
       const value = parseInt(args[0]);
       modifiers.push({ key: 'input', value: value });
     }
-      
-    const outcome = dice.roll(modifiers);
-    const outcomeMessages = movesHelper.createMessages(hunter.firstName, outcome.total, moveContext);
+    
+    // If a hunter has advanced a move, 
+    // they gain access to an even better result if a 12 or more is rolled.
+    const isMoveAdvanced = hunter.advancedMoves
+      && hunter.advancedMoves.length > 0
+      && hunter.advancedMoves.findIndex(am => am.key === alias) > -1;
+
+    const outcome = dice.roll(modifiers);    
+    const outcomeMessages = movesHelper.createMessages(hunter.firstName, outcome.total, moveContext, isMoveAdvanced);
 
     message.channel.send(`${hunter.firstName} rolls ${outcome.equation}`);
     message.channel.send(outcomeMessages.actionReport);

--- a/utils/hunter.js
+++ b/utils/hunter.js
@@ -1,3 +1,5 @@
+const Discord = require('discord.js');
+
 const someHunter = {
   "charm": 0,
   "cool": 0,
@@ -15,21 +17,34 @@ const someHunter = {
 }
 
 function statsEmbed(hunter) {
-  return {
+  let embed = new Discord.MessageEmbed();
+
+  const fields = [
+    {
+      name: `:heart: ${hunter.harm}   :four_leaf_clover: ${hunter.luck}   :military_medal:${hunter.experience}`,
+      value: `Charm: ${hunter.charm}\n`
+      + `Cool: ${hunter.cool}\n`
+      + `Sharp: ${hunter.sharp}\n`
+      + `Tough: ${hunter.tough}\n`
+      + `Weird: ${hunter.weird}\n`, 
+    }
+  ];
+
+  // handle advanced moves
+  if (hunter.advancedMoves && hunter.advancedMoves.length > 0) {
+    let moveString = '';
+    hunter.advancedMoves.forEach(move => moveString += ` - ${move.value} \n`);
+    fields.push({name: 'Advanced Moves', value: moveString});
+  }
+
+  embed = {
     color: 0x0099ff,
     title: `${hunter.firstName} ${hunter.lastName}`,
     description: `${hunter.type}\n`,
-    fields: [
-      {
-        name: `:heart: ${hunter.harm}   :four_leaf_clover: ${hunter.luck}   :military_medal:${hunter.experience}`,
-        value: `Charm: ${hunter.charm}\n`
-        + `Cool: ${hunter.cool}\n`
-        + `Sharp: ${hunter.sharp}\n`
-        + `Tough: ${hunter.tough}\n`
-        + `Weird: ${hunter.weird}\n`, 
-      }
-    ]
-  }
+    fields: fields
+  };
+
+  return embed;
 };
 
 module.exports = { statsEmbed, someHunter };

--- a/utils/moves.js
+++ b/utils/moves.js
@@ -184,7 +184,7 @@ const ms = {
   },
   outcome: {
     fail: {
-      title: 'On a Failed Manipulate Somone...',
+      title: 'On a Failed Manipulate Someone...',
       description: `Offends the target or comes across as obtuse or annoying. Targets may see through a disguise, or refuse to believe a critical lie (or truth!). If used on another hunter, they mark experience if they decide not to do what you ask.`,
 
       footer: {
@@ -192,7 +192,7 @@ const ms = {
       }
     },
     success: {
-      title: 'On a 7-9 Manipulate Somone...',
+      title: 'On a 7-9 Manipulate Someone...',
       description: `For charming a normal person:\n`
         + `They’ll do it, but only if you do something for them right now to show that you mean it. If you asked too much, they’ll tell you what, if anything, it would take for them to do it.\n`
         + '\n'
@@ -245,7 +245,7 @@ const ps = {
         + ` - You hold the enemy back.`
     },
     advanced: {
-      title: 'On a 12+ Protect Somone...',
+      title: 'On a 12+ Protect Someone...',
       description: 'Both you and the character you are protecting are unharmed and out of danger. If you were protecting a bystander, they also become your ally.'
     }
   }

--- a/utils/movesHelper.js
+++ b/utils/movesHelper.js
@@ -1,6 +1,21 @@
-function createMessages(name, total, moveContext) {
+function createMessages(name, total, moveContext, advanced) {
   
-  if (total < 7) {
+  if (total >= 12 && advanced) {
+    return {
+      actionReport: `Wow! ${name} just crushed ${moveContext.name} with a roll of ${total}!`,
+      outcomeReport: moveContext.outcome.advanced,
+    };
+  } else if (total >= 10) {
+    return {
+      actionReport: `Hey! ${name} just rolled a solid ${total} on ${moveContext.name}!`,
+      outcomeReport: moveContext.outcome.high,
+    };
+  } else if (total >= 7) {
+    return {
+      actionReport: `${name} just rolled ${total} on ${moveContext.name}.`,
+      outcomeReport: moveContext.outcome.success,
+    };
+  } else {
     return {
       actionReport: { 
         embed: {
@@ -10,24 +25,6 @@ function createMessages(name, total, moveContext) {
         }
       },
       outcomeReport: moveContext.outcome.fail,
-    }
-  }
-  else if (total < 10) {
-    return {
-      actionReport: `${name} just rolled ${total} on ${moveContext.name}.`,
-      outcomeReport: moveContext.outcome.success,
-    };
-  }
-  else if (total < 12) {
-    return {
-      actionReport: `Hey! ${name} just rolled a solid ${total} on ${moveContext.name}!`,
-      outcomeReport: moveContext.outcome.high,
-    };
-  }
-  else {
-    return {
-      actionReport: `Wow! ${name} just crushed ${moveContext.name} with a roll of ${total}!`,
-      outcomeReport: moveContext.outcome.advanced,
     };
   }
 

--- a/utils/params.js
+++ b/utils/params.js
@@ -1,3 +1,5 @@
+const moves =  require('../utils/moves');
+
 function checkAllArgs(args, check) {
   
   for (let i = 0; i < args.length; i++) {
@@ -40,7 +42,6 @@ function parseUpdateProperty(args) {
   }
 
   return { key, value: value };
-
 }
 
 function parseNumber(arg) {
@@ -167,8 +168,6 @@ function isUserMention(arg) {
   return false;
 }
 
-
-
 function parseSpecialMoveKey(args) {
   
   const possibleMove = (arg) => {
@@ -183,6 +182,16 @@ function parseSpecialMoveKey(args) {
   return checkAllArgs(args, possibleMove);
 }
 
+function parseBasicMoveKey(args) {
+
+  return checkAllArgs(args, (arg) => {
+    if (moves[arg.toLowerCase()]) {
+      return { key: arg.toLowerCase(), value: moves[arg.toLowerCase()].name }
+    }
+  });
+
+}
+
 module.exports = { 
   checkAllArgs,
   parseUserIdFromMentionParam,
@@ -191,4 +200,5 @@ module.exports = {
   parseSpecialMoveKey,
   parseAllForNumber,
   parseInventoryUpdate,
+  parseBasicMoveKey
 };


### PR DESCRIPTION
Add "advanceMove" command which allows hunters to advanceMoves when they reach 5 xp.

Reconfigure stats template to show advanced moves if present.

Then reconfigure basic moves for this new logic, which only allows advanced outcomes when a hunter has advancedMoves.

Stats with advanced move
![image](https://user-images.githubusercontent.com/21226878/99405522-7ceb0980-28b2-11eb-8071-e0172fe98920.png)

12+ roll with Advanced Move (uses 12+ (advanced) outcomes)
![image](https://user-images.githubusercontent.com/21226878/99405607-8d9b7f80-28b2-11eb-8b62-e791ef19686e.png)

12+ roll without Advanced Move (still just uses 10+ (non-advanced) outcomes).
![image](https://user-images.githubusercontent.com/21226878/99405726-aefc6b80-28b2-11eb-9cb1-a14110f286ee.png)
